### PR TITLE
Add a new endpoint to generate a joke based on the time of day

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -10,4 +10,19 @@ app.get("/joke", (_req, res) => {
     res.status(200).send("What do you call a bear with no teeth? A gummy bear!")
 })
 
+// Endpoint to show a joke of the day based on the time of day
+app.get("/joke-of-the-day", (_req, res) => {
+    const jokes = [
+        "Why don't scientists trust atoms? Because they make up everything!",
+        "Why did the scarecrow win an award? Because he was outstanding in his field!",
+        "Why don't skeletons fight each other? They don't have the guts!",
+        "What do you call fake spaghetti? An impasta!",
+        "Why did the bicycle fall over? Because it was two-tired!"
+    ];
+
+    const hour = new Date().getHours();
+    const jokeIndex = hour % jokes.length;
+    res.status(200).send(jokes[jokeIndex]);
+})
+
 module.exports = app;

--- a/src/app.test.js
+++ b/src/app.test.js
@@ -17,3 +17,22 @@ describe('/joke endpoint', () => {
         expect(response.text).toBe('What do you call a bear with no teeth? A gummy bear!');
     });
 });
+
+describe('/joke-of-the-day endpoint', () => {
+    it('should return a joke based on the time of day', async () => {
+        const hour = new Date().getHours();
+        const jokes = [
+            "Why don't scientists trust atoms? Because they make up everything!",
+            "Why did the scarecrow win an award? Because he was outstanding in his field!",
+            "Why don't skeletons fight each other? They don't have the guts!",
+            "What do you call fake spaghetti? An impasta!",
+            "Why did the bicycle fall over? Because it was two-tired!"
+        ];
+        const jokeIndex = hour % jokes.length;
+        const expectedJoke = jokes[jokeIndex];
+
+        const response = await request.get('/joke-of-the-day');
+        expect(response.status).toBe(200);
+        expect(response.text).toBe(expectedJoke);
+    });
+});


### PR DESCRIPTION
Add a new endpoint to generate a joke based on the time of day.

* Add a new endpoint `/joke-of-the-day` in `src/app.js` that returns a joke based on the time of day.
* Implement logic to select a joke from a list of 5 jokes based on the current hour.
* Add tests for the `/joke-of-the-day` endpoint in `src/app.test.js` to verify the correct joke is returned based on the time of day.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/teranth/github_actions_testing?shareId=e11fb9de-2d55-4bea-927e-659f7462d288).